### PR TITLE
Local, but non-existing references

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -2,8 +2,6 @@
 
 ## Current code
 
-* If the diff file is not reachable, it will be silently ignored. Ideally, the corresponding code should then be removed from the generated code! In general, if a reference cannot be reached, then the reference should probably be removed.
-
 
 # Quality todo-s
 

--- a/rp2epub/document.py
+++ b/rp2epub/document.py
@@ -131,6 +131,14 @@ class Document:
 
 						# Change the original reference
 						element.set(attr, final_target)
+					else:
+						# That resource is not available
+						# Typical situation where it happens: the document is generated from respec
+						# on the fly but from a place where the diff file is not yet
+						# generated (but referenced from content)
+						# Take out those situations that are under the control of this script
+						if not element.get(attr).startswith("Assets/"):
+							element.attrib.pop(attr)
 
 	###################################################################################################
 	# noinspection PyPep8
@@ -146,7 +154,7 @@ class Document:
 
 		# The reference to the W3C logo should be localized
 		for img in self.html.findall(".//img[@alt='W3C']"):
-			img.set('src','Assets/w3c_home.png')
+			img.set('src', 'Assets/w3c_home.png')
 			break
 
 		# handle stylesheet references


### PR DESCRIPTION
In case of local, but non-existing references the corresponding <a> element is removed (well, its href attribute is removed and the XHTML serialization removes the empty element, too). The typical case is when the diff file is not (yet) available.
